### PR TITLE
chore: disable copyright year validation in header-checker-lint

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -39,3 +39,9 @@ sourceFileExtensions:
   - 'txt'
   - 'yaml'
   - 'yml'
+
+
+# Migration Settings
+## By default, new files must be created with the current year.
+## During wide-scale file migrations, ignore this enforcement.
+ignoreLicenseYear: true


### PR DESCRIPTION
Noted in the change comment, this is intended as a temporary change during general migration of samples into this repo.