### PR TITLE
feat: Adding UST metadata for tests using Terraform

### DIFF
--- a/products/storage/metadata/storage_move_file.toml
+++ b/products/storage/metadata/storage_move_file.toml
@@ -1,0 +1,132 @@
+region_tag = ["storage_move_file"]
+creation_date = 2023-12-06
+modification_date = 2023-12-06
+title = "Move/rename file in Google Cloud Storage bucket"
+description = "Moves or renames a file inside a storage bucket. Not suitable to move files between buckets."
+standalone = true
+deprecated = false
+# What kinds of preconditions needs to be met. Natural language. (optional)
+requirements = "The bucket and the file must exist. User needs to have write permission to the bucket."
+# What will happen when the code sample in the region tag gets executed. Natural Language. (optional)
+effects = "File is moved/renamed."
+
+[requirements]
+# List of services that need to be enabled for the sample (and tests) to work.
+# The system will use `gcloud services enable <api>` to turn them all on.
+apis = [
+    'storage.googleapis.com'
+]
+# What permissions are needed for the code sample to properly work.
+required_permissions = [
+    'storage.objects.update',
+    'storage.objects.get',
+    'storage.objects.create'
+]
+# What roles can be used to provide neccessary permissions.
+# Those should be predefined roles, but in case you want to use a custom role, use it in the form of:
+# projects/<project_name>/roles/<role_name>
+# So it is clear that it is a custom role.
+required_roles = [
+    'roles/storage.objectUser'
+]
+
+
+
+[[tests]]
+# Indicates if the resoruces prepared in the setup section can be shared between tests.
+# This is used to tests that don't alter the resources (i.e. listing PubSub topics).
+# If set to false, setup and cleanup will happen for each language separately.
+# If set to true, setup and cleanup will happen only once.
+shared_resources = false
+
+# How many tests from this set can be executed at the same time. Needed in case of limited resources.
+# Different versions of a language are treated as separate language.
+parallel_limit = 16
+
+[tests.variables]
+# The series of #### gets replaced by random string to generate unique IDs.
+# A different value is prepared for each test language. Different versions of a language
+# count as different languages.
+BUCKET_NAME = 'test-bucket-#####'
+FILE_NAME = 'test-file-#####'
+NEW_FILE_NAME = 'test-file-#####'
+
+[tests.setup]
+# Terraform setup will implicitly execute `terraform init` and `terraform apply`
+# passing all variables from above as `-var="<key> = <value>"
+# Passing the files that are to be applied to set up the environment
+terraform = ["tf/storage_move_file/single_bucket_move.tf"]
+
+[tests.check]
+# Using ! to fail if there is our template present in the returned list
+command = "gsutil ls gs://$BUCKET_NAME/ | grep $NEW_FILE_NAME"
+
+[tests.cleanup]
+# Make sure the template is deleted. If the command can fail, use `|| true` to supress the failure.
+# In this case, it WILL fail, if the test was successful, so we want to ignore this failure.
+# Since Terraform was used to set up the environment, it will be automatically used to clean up using
+# `terraform destroy`. However, since some resources might not longer be under Terraform control, we have an option to
+# execute some commands before `terraform destroy` takes place.
+commands = ["gsutil rm -f gs://$BUCKET_NAME/$NEW_FILE_NAME"]
+
+[tests.python]
+# We can specify which versions of a language we want to test against.
+versions = ["3.8", "3.12"]
+# Legacy tests skip setup, cleanup and check. They only execute the method pointed to and check if it failed.
+legacy = false
+file = "../python/storage_move_file.py"
+method = "move_blob"
+# Parameters can be strings, integers and floats. Define appropriate value in TOML - it supports ints and floats!
+parameters = ["$BUCKET_NAME", "$FILE_NAME", "$BUCKET_NAME", "$NEW_FILE_NAME"]
+# Those packages will be installed before executing the Python sample.
+requirements = "../python/templates/requirements.txt"
+
+[tests.java]
+versions = ["11", "17", "21"]
+# Legacy tests skip setup, cleanup and check. They only execute the method pointed to and check if it failed.
+legacy = false
+# Name of the class can be derived from the file name.
+file = "../java/src/main/java/MoveObject.java"
+# The method has to be public and static, so it can be called from outside the class
+method = "moveObject"
+# Parameters can be strings, integers and floats. Define appropriate value in TOML - it supports ints and floats!
+parameters = ["$PROJECT_ID", "$BUCKET_NAME", "$FILE_NAME", "$BUCKET_NAME", "$NEW_FILE_NAME"]
+# Those packages will be installed before compiling and executing the Java sample.
+pom = "../java/src/pom.xml"
+
+[[tests]] # Second set of tests to check moving between buckets
+
+shared_resources = false
+parallel_limit = 16
+
+[tests.variables]
+BUCKET_NAME = 'test-bucket-#####'
+NEW_BUCKET_NAME = 'test-bucket-#####'
+FILE_NAME = 'test-file-#####'
+NEW_FILE_NAME = 'test-file-#####'
+
+
+[tests.setup]
+terraform = ["tf/storage_move_file/move_between_buckets.tf"]
+
+[tests.check]
+command = "gsutil ls gs://$NEW_BUCKET_NAME/ | grep $NEW_FILE_NAME"
+
+[tests.cleanup]
+commands = ["gsutil rm -f gs://$NEW_BUCKET_NAME/$NEW_FILE_NAME"]
+
+[tests.python]
+versions = ["3.8", "3.12"]
+legacy = false
+file = "../python/storage_move_file.py"
+method = "move_blob"
+parameters = ["$BUCKET_NAME", "$FILE_NAME", "$NEW_BUCKET_NAME", "$NEW_FILE_NAME"]
+requirements = "../python/templates/requirements.txt"
+
+[tests.java]
+versions = ["11", "17", "21"]
+legacy = false
+file = "../java/src/main/java/MoveObject.java"
+method = "moveObject"
+parameters = ["$PROJECT_ID", "$BUCKET_NAME", "$FILE_NAME", "$NEW_BUCKET_NAME", "$NEW_FILE_NAME"]
+pom = "../java/src/pom.xml"

--- a/products/storage/metadata/tf/storage_move_file/move_between_buckets.tf
+++ b/products/storage/metadata/tf/storage_move_file/move_between_buckets.tf
@@ -1,0 +1,41 @@
+variable "bucket_name" {
+    type        = string
+}
+variable "new_bucket_name" {
+    type        = string
+}
+variable "file_name" {
+    type        = string
+}
+
+resource "google_storage_bucket" "default" {
+  name          = var.bucket_name
+  location      = "EU"
+  force_destroy = true
+
+  public_access_prevention = "enforced"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket" "default2" {
+  name          = var.new_bucket_name
+  location      = "EU"
+  force_destroy = true
+
+  public_access_prevention = "enforced"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "default" {
+  name   = var.file_name
+  content = " this is the content! "
+  bucket = google_storage_bucket.default.name
+}
+
+
+# export TF_VAR_bucket_name = some-random-name
+# export TF_VAR_new_bucket_name = some-random-name2
+# export TF_VAR_file_name = another-random-name
+# terraform apply
+# or
+# terraform apply -var="bucket_name=unique-bucket-3135sd" -var="new_bucket_name=unique-bucket-3132sd" -var="file_name=test-file"

--- a/products/storage/metadata/tf/storage_move_file/move_between_buckets.tf
+++ b/products/storage/metadata/tf/storage_move_file/move_between_buckets.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 variable "bucket_name" {
     type        = string
 }

--- a/products/storage/metadata/tf/storage_move_file/single_bucket_move.tf
+++ b/products/storage/metadata/tf/storage_move_file/single_bucket_move.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 variable "bucket_name" {
     type        = string
 }

--- a/products/storage/metadata/tf/storage_move_file/single_bucket_move.tf
+++ b/products/storage/metadata/tf/storage_move_file/single_bucket_move.tf
@@ -1,0 +1,28 @@
+variable "bucket_name" {
+    type        = string
+}
+variable "file_name" {
+    type        = string
+}
+
+resource "google_storage_bucket" "default" {
+  name          = var.bucket_name
+  location      = "EU"
+  force_destroy = true
+
+  public_access_prevention = "enforced"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "default" {
+  name   = var.file_name
+  content = " this is the content! "
+  bucket = google_storage_bucket.default.name
+}
+
+
+# export TF_VAR_bucket_name = some-random-name
+# export TF_VAR_file_name = another-random-name
+# terraform apply
+# or
+# terraform apply -var="bucket_name=unique-bucket-3135sd" -var="file_name=test-file"


### PR DESCRIPTION
Uploading an example that will use Terraform to set up testing environments.

This metadata file also is the first one to feature 2 test cases for single sample.

Terraform would be used by copying the listed `.tf` files into a temporary directory, executing `terraform init` followed by `terraform apply`. Obviously, both need to be successful for the test to continue.

For cleanup, the system will revisit the temporary folder, run `terraform refresh` followed by `terraform destroy`. This will remove any resources that are still under Terrraform control. In case there needs to be some additional cleanup, additional commands will be executed before `terraform destroy`