### PR TITLE
chore: Simplify local renovate preset usage

### DIFF
--- a/.samplesplatform/renovate/go.json5
+++ b/.samplesplatform/renovate/go.json5
@@ -3,6 +3,7 @@
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
+      "matchCategories": ["go"], // DO NOT EDIT: Limits this file's configurations to Go code.
       "groupName": "go-nonmajor",
       "matchUpdateTypes": ["minor", "patch"],
     },

--- a/.samplesplatform/renovate/java.json5
+++ b/.samplesplatform/renovate/java.json5
@@ -1,120 +1,139 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-
   "packageRules": [
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "groupName": "Java --nonmajor",
       "matchUpdateTypes": ["minor", "patch"],
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^com.fasterxml.jackson.core:"
       ],
       "groupName": "Java - Jackson core packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^com.google.appengine:"
       ],
       "groupName": "Java - AppEngine packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^com.google.cloud.bigtable:"
       ],
       "groupName": "Java - Bigtable packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^com.google.cloud.sql:"
       ],
       "groupName": "Java - Cloud SQL connectors"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePrefixes": [
         "com.google"
       ],
       "allowedVersions": "!/.+-sp\\.[0-9]+$/"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^org.apache.beam:"
       ],
       "groupName": "Java - Apache Beam packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "io.grpc:(?:protoc-gen-)?grpc-*"
       ],
       "groupName": "Java - gRPC packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^org.eclipse.jetty:"
       ],
       "groupName": "Java - Jetty packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^io.micronaut(?:\.validation)?:"
       ],
       "groupName": "Java - Micronaut packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^io.quarkus:"
       ],
       "groupName": "Java - Quarkus packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^io.vertx:"
       ],
       "groupName": "Java - Vertx packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^io.opencensus:"
       ],
       "groupName": "Java - OpenCensus packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^org.slf4j:"
       ],
       "groupName": "Java - SLF4J packages"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackageNames": [
         "com.microsoft.sqlserver:mssql-jdbc"
       ],
       "allowedVersions": "/.+jre8.?/"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "scala"
       ],
       "enabled": false
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^spark-sql"
       ],
       "enabled": false
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^jackson-module-scala"
       ],
       "enabled": false
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "org.springframework.boot"
       ],
       "matchCurrentVersion": "!/.*[SNAPSHOT | M]/"
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackageNames": [
         "com.google.apis:google-api-services-dataflow"
       ],
@@ -122,6 +141,7 @@
       "enabled": false,
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "org.springframework.boot"
       ],
@@ -143,6 +163,7 @@
       "allowedVersions": "<3",
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": [
         "^org.eclipse.jetty:"
       ],
@@ -160,6 +181,7 @@
       // Java 8 on App Engine supports servlets V3.1 and Jetty V9 https://cloud.google.com/appengine/docs/flexible/java/runtime. Folders appengine-java1* needs to be migrated
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackagePatterns": ["^io.micronaut"],
       "groupName": "Java - micronaut packages",
       "allowedVersions": "<4",
@@ -170,6 +192,7 @@
       // Micronaut V4 requires Java 17
     },
     {
+      "matchCategories": ["java"], // DO NOT EDIT: Limits this file's configurations to Java code.
       "matchPackageNames": [
         "javax.servlet:javax.servlet-api"
       ],

--- a/.samplesplatform/renovate/javascript.json5
+++ b/.samplesplatform/renovate/javascript.json5
@@ -1,13 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-
   "packageRules": [
     {
+      "matchCategories": ["js", "node"], // DO NOT EDIT: Limits this file's configurations to JavaScript code.
       "groupName": "javascript-nonmajor",
       "matchUpdateTypes": ["minor", "patch"],
     },
     {
-      "groupName": "npm-dev",
+      "matchCategories": ["js", "node"], // DO NOT EDIT: Limits this file's configurations to JavaScript code.
+      "groupName": "javascript-dev",
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "separateMajorMinor": false,

--- a/.samplesplatform/renovate/python.json5
+++ b/.samplesplatform/renovate/python.json5
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-
   "poetry": {
     "fileMatch": ["pyproject.toml"],
   },
@@ -22,18 +21,22 @@
 
   "packageRules": [
     {
+      "matchCategories": ["python"], // DO NOT EDIT: Limits this file's configurations to Python code.
       "groupName": "python-nonmajor",
       "matchUpdateTypes": ["minor", "patch"],
     },
     {
+      "matchCategories": ["python"], // DO NOT EDIT: Limits this file's configurations to Python code.
       "groupName": "OpenTelemetry",
       "matchPackagePrefixes": ["opentelemetry-"],
     },
     {
+      "matchCategories": ["python"], // DO NOT EDIT: Limits this file's configurations to Python code.
       "matchPackagePatterns": ["pytest"],
       "separateMinorPatch": true,
     },
     {
+      "matchCategories": ["python"], // DO NOT EDIT: Limits this file's configurations to Python code.
       "matchPackagePatterns": ["pytest"],
       "matchUpdateTypes": ["patch"],
       "enabled": false

--- a/.samplesplatform/renovate/terraform.json5
+++ b/.samplesplatform/renovate/terraform.json5
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "groupName": "Terraform",
-  "separateMajorMinor": false,
+  "packageRules": {
+    "matchManagers": ["terraform"], // DO NOT EDIT: Limits this file's configurations to Terraform code.
+    "groupName": "Terraform",
+    "separateMajorMinor": false,
+  },
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,7 +5,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base", // https://docs.renovatebot.com/presets-config/#configbase
+    "config:recommended", // https://docs.renovatebot.com/presets-config/#configrecommended
     ":semanticCommits", // https://docs.renovatebot.com/presets-default/#semanticcommits
     ":ignoreUnstable", // https://docs.renovatebot.com/presets-default/#ignoreunstable
     "group:allNonMajor", // https://docs.renovatebot.com/presets-group/#groupallnonmajor
@@ -14,6 +14,24 @@
     ":prNotPending", // https://docs.renovatebot.com/presets-default/#prnotpending
     ":prHourlyLimitNone", // https://docs.renovatebot.com/presets-default/#prhourlylimitnone
     "docker:enableMajor", // https://docs.renovatebot.com/presets-docker/#dockerenablemajor
+
+    // Renovate configuration per supported programming language.
+    // Originally these were included in packageRules in this file, with matching
+    // rules to ensure changes to the individual preset files could not leak.
+    // This practice throws unclear errors, despite theoretical support:
+    // https://github.com/renovatebot/renovate/issues/14974.
+    // Errors occur regardless of including 'packageRules' inside the preset,
+    // and matchNNN rules must sit inside packageRules statements.
+    //
+    // The following rules for language presets are:
+    // - Consistently use a matchNNN rule to silo all package rules
+    // - Ensure any global config would only impact owned language tooling
+    // - There may be rules in the future, such as limiting the number of groups
+    "local>//.samplesplatform/renovate/go",
+    "local>//.samplesplatform/renovate/python",
+    "local>//.samplesplatform/renovate/java",
+    "local>//.samplesplatform/renovate/javascript",
+    "local>//.samplesplatform/renovate/terraform",
   ],
 
   // Synchronized with a 2 week sprint cycle and outside business hours.
@@ -76,37 +94,6 @@
        "groupName": "GitHub Actions",
        "matchManagers": ["github-actions"],
        "pinDigests": true,
-    },
-
-    {
-      "matchCategories": ["go"],
-      "extends": [
-        "local>.samplesplatform/renovate/go",
-      ],
-    },
-    {
-      "matchCategories": ["python"],
-      "extends": [
-        "local>.samplesplatform/renovate/python",
-      ],
-    },
-    {
-      "matchCategories": ["java"],
-      "extends": [
-        "local>.samplesplatform/renovate/java",
-      ],
-    },
-    {
-      "matchManagers": ["terraform"],
-      "extends": [
-        "local>.samplesplatform/renovate/terraform",
-      ],
-    },
-    {
-      "matchCategories": ["js", "node"],
-      "extends": [
-        "local>.samplesplatform/renovate/javascript",
-      ],
     },
 
     // Updating coupled ecosystems.


### PR DESCRIPTION
After further investigation, I've found that Renovate's support for extends inside custom presets is theoretically supported, but undocumented and based on at least one fix for this I've found, something that may be generally subject to breakage.

The changes in this PR use a simpler model of custom presets that validate locally, at the cost of additional noise in each language preset and an increased responsibility within each preset to avoid clobbering the renovate config intentions of other languages.