### PR TITLE
chore: add java package name to metadata

### DIFF
--- a/products/compute/java/src/main/java/snapshot/CreateSnapshot.java
+++ b/products/compute/java/src/main/java/snapshot/CreateSnapshot.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute.disks;
+package snapshot;
 
 // [START compute_snapshot_create]
 

--- a/products/compute/java/src/main/java/templates/DeleteInstanceTemplate.java
+++ b/products/compute/java/src/main/java/templates/DeleteInstanceTemplate.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package compute;
+package templates;
 
 // [START compute_template_delete]
 

--- a/products/compute/java/src/test/java/snapshot/SnapshotsIT.java
+++ b/products/compute/java/src/test/java/snapshot/SnapshotsIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package compute.disks;
+package snapshot;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;

--- a/products/compute/java/src/test/java/templates/InstanceTemplatesIT.java
+++ b/products/compute/java/src/test/java/templates/InstanceTemplatesIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package compute;
+package templates;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;

--- a/products/compute/metadata/create_disk_snapshot.toml
+++ b/products/compute/metadata/create_disk_snapshot.toml
@@ -67,6 +67,8 @@ requirements_test = "../python/snapshot/requirements-test.txt"
 versions = ["11", "17", "21"]
 # Legacy tests skip setup, cleanup and check. They only execute the method pointed to and check if it failed.
 legacy = true
+# Package name of the sample to be tested.
+package_name = "snapshot"
 # Name of the class can be derived from the file name.
 file = "../java/src/main/java/templates/DeleteInstanceTemplate.java"
 # The method has to be public and static, so it can be called from outside the class

--- a/products/compute/metadata/delete_template.toml
+++ b/products/compute/metadata/delete_template.toml
@@ -84,6 +84,8 @@ requirements = "../python/templates/requirements.txt"
 versions = ["11", "17", "21"]
 # Legacy tests skip setup, cleanup and check. They only execute the method pointed to and check if it failed.
 legacy = false
+# Package name of the sample to be tested.
+package_name = "templates"
 # Name of the class can be derived from the file name.
 file = "../java/src/main/java/templates/DeleteInstanceTemplate.java"
 # The method has to be public and static, so it can be called from outside the class

--- a/products/logging/java/src/main/java/logs/ListLogEntries.java
+++ b/products/logging/java/src/main/java/logs/ListLogEntries.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.example.logging;
+package logs;
 
 // [START logging_list_log_entries]
 import com.google.api.gax.paging.Page;

--- a/products/logging/java/src/test/java/logs/LoggingIT.java
+++ b/products/logging/java/src/test/java/logs/LoggingIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.example.logging;
+package logs;
 
 import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
 import static com.google.common.truth.Truth.assertThat;

--- a/products/logging/metadata/list_log_entries.toml
+++ b/products/logging/metadata/list_log_entries.toml
@@ -88,6 +88,8 @@ versions = ["11", "17", "21"]
 # Legacy tests skip setup, cleanup and check. They only execute the method pointed to and check if it failed.
 # TODO: We need to make sure the exceptions are thrown from the tests and not sysout/ printed.
 legacy = true
+# Package name of the sample to be tested.
+package_name = "logs"
 # Name of the class can be derived from the file name.
 file = "../java/src/main/java/ListLogEntries.java"
 # The method has to be public and static, so it can be called from outside the class

--- a/products/storage/java/src/main/java/object/MoveObject.java
+++ b/products/storage/java/src/main/java/object/MoveObject.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.example.storage.object;
+package object;
 
 // [START storage_move_file]
 

--- a/products/storage/java/src/test/java/object/ITObjectSnippets.java
+++ b/products/storage/java/src/test/java/object/ITObjectSnippets.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.example.storage;
+package object;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertArrayEquals;

--- a/products/storage/metadata/storage_move_file.toml
+++ b/products/storage/metadata/storage_move_file.toml
@@ -85,6 +85,8 @@ requirements = "../python/templates/requirements.txt"
 versions = ["11", "17", "21"]
 # Legacy tests skip setup, cleanup and check. They only execute the method pointed to and check if it failed.
 legacy = false
+# Package name of the sample to be tested.
+package_name = "object"
 # Name of the class can be derived from the file name.
 file = "../java/src/main/java/MoveObject.java"
 # The method has to be public and static, so it can be called from outside the class
@@ -126,6 +128,8 @@ requirements = "../python/templates/requirements.txt"
 [tests.java]
 versions = ["11", "17", "21"]
 legacy = false
+# Package name of the sample to be tested.
+package_name = "object"
 file = "../java/src/main/java/MoveObject.java"
 method = "moveObject"
 parameters = ["$PROJECT_ID", "$BUCKET_NAME", "$FILE_NAME", "$NEW_BUCKET_NAME", "$NEW_FILE_NAME"]


### PR DESCRIPTION
1. Adds a new field `package_name` under `tests.java` in metadata files.
2. Move java files into appropriate packages.


