### PR TITLE
chore: enable language labeling for package managers

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -95,6 +95,11 @@ path:
 language:
   pullrequest: true
   labelprefix: 'lang:'
+  extensions:
+    python: ['requirements.txt']
+    js: ['package.json', 'package-lock.json']
+    go: ['go.mod', 'go.sum', 'go.work']
+    java: ['pom.xml']
 
 requestsize:
   enabled: true


### PR DESCRIPTION
Assign several common package manager file names to language labeling. Language-specific dpendency management falls into language practice scope, this way if someone filters issues/PRs for "lang: js" it will include issues with node dependencies.